### PR TITLE
Attempt to fix images occurring out of order

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,39 +17,26 @@
         <p id="ButtonText">Stop</p>
       </button>
 
-      <div id="scroller" style="width: 1900px; height: 1060px; margin: 0 auto;">
+      <div id="scroller">
         <div class="innerScrollArea">
-	      <ul>
-	         <li><img src='./images/01-3.png' alt='01-3.png' width='2500' height='1080'/></li>
-	         <li><img src='./images/02-4.png' alt='02-4.png' width='2084' height='1080'/></li>
-	         <li><img src='./images/03-5.png' alt='03-5.png' width='1980' height='1080'/></li>
-	         <li><img src='./images/04-4.png' alt='04-4.png' width='1980' height='1080'/></li>
-	         <li><img src='./images/05-4.png' alt='05-4.png' width='1950' height='1080'/></li>
-	         <li><img src='./images/06-5.png' alt='06-5.png' width='1950' height='1080'/></li>
-	         <li><img src='./images/07-5.png' alt='07-5.png' width='1888' height='1080'/></li>
-	         <li><img src='./images/08-5.png' alt='08-5.png' width='1876' height='1080'/></li>
-	         <li><img src='./images/09-4.png' alt='09-4.png' width='1975' height='1080'/></li>
-	         <li><img src='./images/10-4.png' alt='10-4.png' width='1973' height='1080'/></li>
-	         <li><img src='./images/11-3.png' alt='11-3.png' width='1884' height='1080'/></li>
-	         <li><img src='./images/12-4.png' alt='12-4.png' width='1867' height='1080'/></li>
-	         <li><img src='./images/13-4.png' alt='13-4.png' width='1950' height='1080'/></li>
-	         <li><img src='./images/14-4.png' alt='14-4.png' width='1950' height='1080'/></li>
-	         <li><img src='./images/15-4.png' alt='15-4.png' width='1960' height='1080'/></li>
-	         <li><img src='./images/16-4.png' alt='16-4.png' width='1960' height='1080'/></li>
-	         <li><img src='./images/17-4.png' alt='17-4.png' width='1951' height='1080'/></li>
-	         <li><img src='./images/18-4.png' alt='18-4.png' width='1953' height='1080'/></li>
-	         <li><img src='./images/19-4.png' alt='19-4.png' width='1953' height='1080'/></li>
-	         <li><img src='./images/20-4.png' alt='20-4.png' width='1953' height='1080'/></li>
-	         <li><img src='./images/21-4.png' alt='21-4.png' width='1875' height='1080'/></li>
-	         <li><img src='./images/22-4.png' alt='22-4.png' width='1873' height='1080'/></li>
-	         <li><img src='./images/23-5.png' alt='23-5.png' width='1953' height='1080'/></li>
-	         <li><img src='./images/24-5.png' alt='24-5.png' width='2400' height='1080'/></li>
-          </ul>
+					<img src='./test/images/01-1.png' alt='01-1.png' width='225' height='800'/>
+					<img src='./test/images/02-2.png' alt='02-2.png' width='225' height='800'/>
+					<img src='./test/images/03-3.png' alt='03-3.png' width='225' height='800'/>
+					<img src='./test/images/04-4.png' alt='04-4.png' width='225' height='800'/>
+					<img src='./test/images/05-5.png' alt='05-5.png' width='225' height='800'/>
+					<img src='./test/images/06-6.png' alt='06-6.png' width='225' height='800'/>
+					<img src='./test/images/07-6.png' alt='07-6.png' width='500' height='800'/>
+					<img src='./test/images/08-6.png' alt='08-6.png' width='600' height='800'/>
+					<img src='./test/images/09-6.png' alt='09-6.png' width='1000' height='800'/>
+					<img src='./test/images/10-3.png' alt='10-3.png' width='225' height='800'/>
+					<img src='./test/images/11-2.png' alt='11-2.png' width='225' height='800'/>
+					<img src='./test/images/12-3.png' alt='12-3.png' width='225' height='800'/>
+					<img src='./test/images/13-1.png' alt='13-1.png' width='225' height='800'/>
        </div>
     </div>
     <div id="output">
 	   <p id="cur"></p>
     </div>
-       <p id='speeds'>345445554434444444444455</p>
+       <p id='speeds'>1234566663231</p>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,5 @@
     <div id="output">
 	   <p id="cur"></p>
     </div>
-       <p id='speeds'>1234566663231</p>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,19 +19,30 @@
 
       <div id="scroller">
         <div class="innerScrollArea">
-					<img src='./test/images/01-1.png' alt='01-1.png' width='225' height='800'/>
-					<img src='./test/images/02-2.png' alt='02-2.png' width='225' height='800'/>
-					<img src='./test/images/03-3.png' alt='03-3.png' width='225' height='800'/>
-					<img src='./test/images/04-4.png' alt='04-4.png' width='225' height='800'/>
-					<img src='./test/images/05-5.png' alt='05-5.png' width='225' height='800'/>
-					<img src='./test/images/06-6.png' alt='06-6.png' width='225' height='800'/>
-					<img src='./test/images/07-6.png' alt='07-6.png' width='500' height='800'/>
-					<img src='./test/images/08-6.png' alt='08-6.png' width='600' height='800'/>
-					<img src='./test/images/09-6.png' alt='09-6.png' width='1000' height='800'/>
-					<img src='./test/images/10-3.png' alt='10-3.png' width='225' height='800'/>
-					<img src='./test/images/11-2.png' alt='11-2.png' width='225' height='800'/>
-					<img src='./test/images/12-3.png' alt='12-3.png' width='225' height='800'/>
-					<img src='./test/images/13-1.png' alt='13-1.png' width='225' height='800'/>
+	         <img src='./images/01-3.png' alt='01-3.png' width='2500' height='1080'/>
+	         <img src='./images/02-4.png' alt='02-4.png' width='2084' height='1080'/>
+	         <img src='./images/03-5.png' alt='03-5.png' width='1980' height='1080'/>
+	         <img src='./images/04-4.png' alt='04-4.png' width='1980' height='1080'/>
+	         <img src='./images/05-4.png' alt='05-4.png' width='1950' height='1080'/>
+	         <img src='./images/06-5.png' alt='06-5.png' width='1950' height='1080'/>
+	         <img src='./images/07-5.png' alt='07-5.png' width='1888' height='1080'/>
+	         <img src='./images/08-5.png' alt='08-5.png' width='1876' height='1080'/>
+	         <img src='./images/09-4.png' alt='09-4.png' width='1975' height='1080'/>
+	         <img src='./images/10-4.png' alt='10-4.png' width='1973' height='1080'/>
+	         <img src='./images/11-3.png' alt='11-3.png' width='1884' height='1080'/>
+	         <img src='./images/12-4.png' alt='12-4.png' width='1867' height='1080'/>
+	         <img src='./images/13-4.png' alt='13-4.png' width='1950' height='1080'/>
+	         <img src='./images/14-4.png' alt='14-4.png' width='1950' height='1080'/>
+	         <img src='./images/15-4.png' alt='15-4.png' width='1960' height='1080'/>
+	         <img src='./images/16-4.png' alt='16-4.png' width='1960' height='1080'/>
+	         <img src='./images/17-4.png' alt='17-4.png' width='1951' height='1080'/>
+	         <img src='./images/18-4.png' alt='18-4.png' width='1953' height='1080'/>
+	         <img src='./images/19-4.png' alt='19-4.png' width='1953' height='1080'/>
+	         <img src='./images/20-4.png' alt='20-4.png' width='1953' height='1080'/>
+	         <img src='./images/21-4.png' alt='21-4.png' width='1875' height='1080'/>
+	         <img src='./images/22-4.png' alt='22-4.png' width='1873' height='1080'/>
+	         <img src='./images/23-5.png' alt='23-5.png' width='1953' height='1080'/>
+	         <img src='./images/24-5.png' alt='24-5.png' width='2400' height='1080'/>
        </div>
     </div>
     <div id="output">

--- a/index.php
+++ b/index.php
@@ -17,39 +17,31 @@
         <p id="ButtonText">Stop</p>
       </button>
 			
-      <div id="scroller" style="width: 1900px; height: 1060px; margin: 0 auto;">
+      <div id="scroller">
         <div class="innerScrollArea">			
-	   <?php
-	      $speed = "";
-	      $dir = "./images";
-	      $file_types = array('jpg', 'jpeg', 'gif', 'png');
-	      if (file_exists($dir) == true) {
-		 echo "   <ul>";
-		 $dir_contents = scandir($dir);		
-		 foreach ($dir_contents as $file) {
-		    $extention = pathinfo($file, PATHINFO_EXTENSION);
-		    $name = basename($file);
-		    $speed .= $name[3];
-		    if (in_array($extention, $file_types) == true) {
-                       $filename = $dir . "/" . $file;
-                       list($width, $height, $type, $attr) = getimagesize($filename);
-		       echo "\r\n	         ";
-                       echo "<li><img src='" . $dir. "/" . $file . "' alt='" . $file . "' width='".$width."' height='".$height."'/></li>";
-		    }
-		  }
-		  echo "\r\n          </ul>\r\n";
-	       }
-	       else {
-		  echo "<p>Empty folder</p>";
-	       }
-	     ?>
+        <?php
+          $dir = "./images";
+          $file_types = array('jpg', 'jpeg', 'gif', 'png');
+          if (file_exists($dir) == true) {
+            $dir_contents = scandir($dir);
+            foreach ($dir_contents as $file) {
+              $extention = pathinfo($file, PATHINFO_EXTENSION);
+              $name = basename($file);
+              if (in_array($extention, $file_types) == true) {
+                $filename = $dir . "/" . $file;
+                list($width, $height, $type, $attr) = getimagesize($filename);
+                echo "\r\n	         ";
+                echo "<img src='" . $dir. "/" . $file . "' alt='" . $file . "' width='".$width."' height='".$height."'/>";
+              }
+            }
+          } else {
+            echo "<p>Empty folder</p>";
+          }
+        ?>
        </div>
     </div>
     <div id="output">
 	   <p id="cur"></p>
     </div>
-       <?php
-          echo "<p id='speeds'>" . $speed . "</p>\r\n";
-       ?>
     </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -71,7 +71,7 @@ $(function(){
 		}
 	
 	};
-	//startButton.click(startStop);
+	startButton.click(startStop);
 	
 	// Start scrolling
 	var pic = 0;
@@ -125,7 +125,7 @@ $(function(){
 			toNewSpeed(speed);
 		    event.preventDefault();
 		}
-		else if (event.which == '32') {  spacebar
+		else if (event.which == '32') {  //spacebar
 			startStop();
 			event.preventDefault();
 		}

--- a/script.js
+++ b/script.js
@@ -38,7 +38,6 @@ $(function(){
 	listWidth.push("0");
 	scrollerContent.children().each(function(){
 		var $this = $(this);
-		$this.css('left', currentX);
 		currentX += $this.outerWidth(true);
 		listWidth.push(currentX);
 	});

--- a/script.js
+++ b/script.js
@@ -86,9 +86,13 @@ $(function(){
 	// Represents how many pixels the image display is shifted to the left
 	var currentX = 0;
 	var scroll = function() {
-		// if the current image is the last image, stop the scroll
-		// (e.g. if we have images [1, 2, 3] and imgId is 3, stop scrolling)
-		if (imgId >= images.length) {
+		// if:
+		//   1. the current image is the last image
+		//      (e.g. if we have images [1, 2, 3] and imgId is 3)
+		//   2. the right edge of the image is visible
+		//      (i.e. currentX is at least imgBoundary + (image width - scroller width))
+		// then stop the scroll
+		if (imgId >= images.length && currentX >= imgBoundary + (images[imgId - 1].width - scroller[0].getBoundingClientRect().width)) {
 			toNewSpeed(0);
 			clearInterval(interval);
 			return;
@@ -99,14 +103,14 @@ $(function(){
 		// shift the image display left by currentX pixels
 		scroller[0].style.transform = `translateX(-${currentX}px)`
 		// if we've crossed over into a new image,
-		if (currentX > imgBoundary + images[imgId].width) {
+		if (currentX > imgBoundary + images[imgId - 1].width) {
 			// if we haven't set a custom speed, change the speed to that of the new image
 			if (!customizedSpeed) {
 				speed = speeds[imgId + 1];
 				toNewSpeed(speed);
 			}
 			// add the previous image's width to imgBoundary
-			imgBoundary += images[imgId].width;
+			imgBoundary += images[imgId - 1].width;
 			// increase imgId by 1 (assumes image IDs progress linearly from 1 to n)
 			imgId++;
 		}

--- a/script.js
+++ b/script.js
@@ -20,23 +20,30 @@ $(function(){
 		var output = document.getElementById("output");
 		output.appendChild(paragraph);
 	}
+
+	// given an image URL, extract all the info that's contained in the filename.
+	// (e.g. ID and speed)
+	function getImageInfo(imageLocation) {
+		// replace everything before the last / or \ with an empty string to get the filename.
+		const fileName = imageLocation.replace(/^.*[\\\/]/, '');
+		// remove the extension
+		const fileNameWithoutExtension = fileName.split('.')[0];
+		const [id, speed] = fileNameWithoutExtension.split('-').map(Number);
+		return { id, speed };
+	}
 	
 	// Setup
-	var speeds = $("#speeds").text();
 	var customizedSpeed = false; 
 	var scroller = $('#scroller div.innerScrollArea');
 	var startButton = $('#startButton');
 	var boolSwitch = true;
-	var scrollerContent = scroller.children('ul');
-	//
-	// I commented out the following line. It seemed to duplicate each <li> image a
-	// second time and that didn't seem right, but I could be wrong --LS 11.12.2016
-	//
-	//scrollerContent.children().clone().appendTo(scrollerContent);
+	const speeds = new Array(scrollerContent.length);
+
 	var currentX = 0;
-	var listWidth = new Array();
-	listWidth.push("0");
-	scrollerContent.children().each(function(){
+	var listWidth = [0];
+	scroller.children('img').each(function(){
+		const { id, speed } = getImageInfo(this.src);
+		speeds[id] = speed;
 		var $this = $(this);
 		currentX += $this.outerWidth(true);
 		listWidth.push(currentX);
@@ -87,7 +94,7 @@ $(function(){
 		
 		if (listWidth[pic] < currentX) {
 			if (customizedSpeed == false) {
-				speed = speeds.charAt(pic+1);
+				speed = speeds[pic + 1];
 				toNewSpeed(speed);
 			}
 			pic += 1;

--- a/styles.css
+++ b/styles.css
@@ -1,25 +1,11 @@
 #scroller {
-    position: relative;
+	position: relative;
+	margin: 0 auto;
 }
 #scroller .innerScrollArea {
 	overflow: hidden;
-	position: absolute;
-	left: 0;
-	right: 0;
-	top: 0;
-	bottom: 0;
-}
-#scroller ul {
-	padding: 0;
-	margin: 0;
-	position: relative;
-}
-#scroller li {
-	padding: 0;
-	margin: 0;
-	list-style-type: none;
-	position: absolute;
+	display: flex;
 }
 #speeds {
-	color: white;
+	display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,8 @@
 #scroller {
 	position: relative;
 	margin: 0 auto;
+	overflow: hidden;
 }
 #scroller .innerScrollArea {
-	overflow: hidden;
 	display: flex;
 }

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,3 @@
 	overflow: hidden;
 	display: flex;
 }
-#speeds {
-	display: none;
-}


### PR DESCRIPTION
Few changes here:

* Fixed start/stop and spacebar to stop
* Read speeds from the image filenames directly rather than having PHP create a separate `speeds` string. No bug here, but avoids some duplication of information.
* Lay out images horizontally using flexbox to avoid having to manually specify a pixel position for each image. I didn't find evidence that it was causing a problem, but there may have been a case where the image positions were out of order.
* Image elements are forcibly sorted by ID in the image filename after the page is loaded. I didn't have luck reproducing the images displaying out of order on the plain HTML/JS page, so I was curious if it might be a PHP-related issue.
* Scrolling stops when reaching the end of the images. There is currently some looping behavior, but I'm not sure it was working as intended.

Fixes #1 